### PR TITLE
Removed precision option from design tokens export

### DIFF
--- a/src/lib/components/export/Export.svelte
+++ b/src/lib/components/export/Export.svelte
@@ -189,7 +189,7 @@
 					</fieldset>
 				{/if}
 
-				{#if $exportColorFormat !== 'hex' && $exportColorFormat !== 'rgb'}
+				{#if $exportFormat !== 'tokens' && $exportColorFormat !== 'hex' && $exportColorFormat !== 'rgb'}
 					<label for="precision">Precision</label>
 					<input
 						id="precision"


### PR DESCRIPTION
This option makes no sense as design tokens must be formatted as hex codes.