### PR TITLE
Fixed sampling type of contrasting node

### DIFF
--- a/src/lib/definitions/nodes/contrasting.ts
+++ b/src/lib/definitions/nodes/contrasting.ts
@@ -17,7 +17,7 @@ export default {
 			default: 80
 		}
 	],
-	samples: 'single',
+	samples: 'continuous',
 	apply(color, {amount}) {
 		return contrastingColor(color, amount);
 	}


### PR DESCRIPTION
The range is now shown as a continuous gradient instead of discrete steps.