### PR TITLE
Showing RGB panel by default - fixes #41

### DIFF
--- a/src/lib/components/forms/ColorField.svelte
+++ b/src/lib/components/forms/ColorField.svelte
@@ -13,7 +13,7 @@
 	export let param: Param;
 	export let value: SchemistColor;
 
-	let format: InputFormat = 'css';
+	let format: InputFormat = 'rgb';
 </script>
 
 <div class="input-grid-firstCol input-grid-lastCol">
@@ -31,20 +31,6 @@
 					role="group"
 					aria-labelledby="{id}-format"
 				>
-					<input
-						id="{id}-css"
-						class="button-trigger hidden"
-						type="radio"
-						value="css"
-						bind:group={format}
-					/>
-					<label
-						class="button button--inline"
-						for="{id}-css"
-					>
-						CSS
-					</label>
-
 					<input
 						id="{id}-rgb"
 						class="button-trigger hidden"
@@ -85,6 +71,20 @@
 						for="{id}-lch"
 					>
 						LCH
+					</label>
+
+					<input
+						id="{id}-css"
+						class="button-trigger hidden"
+						type="radio"
+						value="css"
+						bind:group={format}
+					/>
+					<label
+						class="button button--inline"
+						for="{id}-css"
+					>
+						CSS
 					</label>
 				</div>
 


### PR DESCRIPTION
RGB is the most widely known format, and range sliders are more inviting to play with than the text input from the CSS panel.